### PR TITLE
[Feat] Apply the 2FA support to the yakumo's publishing hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "mocha": "^9.2.2",
     "shx": "^0.3.4",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "yakumo": "^0.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
     "mocha": "^9.2.2",
     "shx": "^0.3.4",
     "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "yakumo": "^0.3.6"
   }
 }

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -36,22 +36,17 @@ function getPublishCommand(manager: Manager) {
   return ['yarn', 'npm']
 }
 
-function publish(manager: Manager, path: string, name: string, version: string, tag: string, access: string,faCode:string="") {
+function publish(manager: Manager, path: string, name: string, version: string, tag: string, access: string, otp = '') {
   console.log(`publishing ${name}@${version} ...`)
-  let spawnAsyncConfig=[
+  const args = [
     ...getPublishCommand(manager),
     'publish', path.slice(1),
     '--tag', tag,
     '--access', access,
     '--color',
   ]
-  //logic in detecting isUsing2FAMode
-  let isUsing2FAMode=faCode==""?false:true
-  if(isUsing2FAMode){
-    spawnAsyncConfig.push('--otp')
-    spawnAsyncConfig.push(faCode)
-  }
-  return spawnAsync(spawnAsyncConfig, {
+  if (otp) args.push('--otp', otp)
+  return spawnAsync(args, {
     stdio: ['ignore', 'ignore', 'pipe'],
   })
 }
@@ -93,8 +88,7 @@ register('publish', async (project) => {
   for (const path in targets) {
     const { name, version } = targets[path]
     await project.emit('publish.before', path, targets[path])
-    //detecting the argument which is caused the enter 2FACodeMode
-    await publish(project.manager, path, name, version, argv.tag ?? (isNext(version) ? 'next' : 'latest'), argv.access ?? 'public',argv.otp==undefined?"":argv.otp)
+    await publish(project.manager, path, name, version, argv.tag ?? (isNext(version) ? 'next' : 'latest'), argv.access ?? 'public', argv.otp)
     await project.emit('publish.after', path, targets[path])
   }
 


### PR DESCRIPTION
Nowadays, I have got some problems in the publishing the Koishi's plugin. Such as the authentication of the npm's. And I'm using the 2FACode to login the npm. But the publishing script cannot figure it out.So I wrote the functions of it.